### PR TITLE
Change `archive_path` to support XCode10

### DIFF
--- a/lib/xccoveralls/xccov.rb
+++ b/lib/xccoveralls/xccov.rb
@@ -26,7 +26,7 @@ module Xccoveralls
     def archive_path
       return @archive_path if @archive_path
       ext = '.xccovarchive'
-      files = Dir[File.join(test_logs_path, "*#{ext}")]
+      files = Dir[File.join(test_logs_path, "**/*#{ext}")]
       @archive_path = files.sort_by { |filename| File.mtime(filename) }
                            .reverse.first
       @archive_path ||


### PR DESCRIPTION
# Purpose
The output path of Xcode coverage tool has changed.

Xcode9 : `DerivedData/{build}/Logs/Test/{testpass}.xcovreport`
Xcode10+ : `DerivedData/{build}/Logs/Test/{testpass}.xcresult/{#}_Test/action.xcovreport`

`archive_path` should change search path to support new path after XCode10.

# Changes
- Change the search path to recursive find path of `.xccovarchive`